### PR TITLE
fix(components): remove hsl wrapper from color variables

### DIFF
--- a/registry/default/blocks/charts/area-charts/area-chart-2.tsx
+++ b/registry/default/blocks/charts/area-charts/area-chart-2.tsx
@@ -221,54 +221,30 @@ export default function AreaChart2() {
                   {/* Diagonal grid lines */}
                   <path
                     d="M0,16 L32,16 M16,0 L16,32"
-                    stroke="hsl(var(--muted-foreground))"
+                    stroke="var(--muted-foreground)"
                     strokeWidth="0.5"
                     strokeOpacity="0.03"
                   />
                   <path
                     d="M0,0 L32,32 M0,32 L32,0"
-                    stroke="hsl(var(--muted-foreground))"
+                    stroke="var(--muted-foreground)"
                     strokeWidth="0.3"
                     strokeOpacity="0.02"
                   />
 
                   {/* Modern geometric elements */}
-                  <circle cx="8" cy="8" r="1.5" fill="hsl(var(--muted-foreground))" fillOpacity="0.04" />
-                  <circle cx="24" cy="24" r="1.5" fill="hsl(var(--muted-foreground))" fillOpacity="0.04" />
+                  <circle cx="8" cy="8" r="1.5" fill="var(--muted-foreground)" fillOpacity="0.04" />
+                  <circle cx="24" cy="24" r="1.5" fill="var(--muted-foreground)" fillOpacity="0.04" />
 
                   {/* Abstract rounded rectangles */}
-                  <rect
-                    x="12"
-                    y="4"
-                    width="8"
-                    height="2"
-                    rx="1"
-                    fill="hsl(var(--muted-foreground))"
-                    fillOpacity="0.02"
-                  />
-                  <rect
-                    x="4"
-                    y="26"
-                    width="8"
-                    height="2"
-                    rx="1"
-                    fill="hsl(var(--muted-foreground))"
-                    fillOpacity="0.02"
-                  />
-                  <rect
-                    x="20"
-                    y="12"
-                    width="2"
-                    height="8"
-                    rx="1"
-                    fill="hsl(var(--muted-foreground))"
-                    fillOpacity="0.02"
-                  />
+                  <rect x="12" y="4" width="8" height="2" rx="1" fill="var(--muted-foreground)" fillOpacity="0.02" />
+                  <rect x="4" y="26" width="8" height="2" rx="1" fill="var(--muted-foreground)" fillOpacity="0.02" />
+                  <rect x="20" y="12" width="2" height="8" rx="1" fill="var(--muted-foreground)" fillOpacity="0.02" />
 
                   {/* Minimal dots */}
-                  <circle cx="6" cy="20" r="0.5" fill="hsl(var(--muted-foreground))" fillOpacity="0.06" />
-                  <circle cx="26" cy="10" r="0.5" fill="hsl(var(--muted-foreground))" fillOpacity="0.06" />
-                  <circle cx="14" cy="28" r="0.5" fill="hsl(var(--muted-foreground))" fillOpacity="0.06" />
+                  <circle cx="6" cy="20" r="0.5" fill="var(--muted-foreground)" fillOpacity="0.06" />
+                  <circle cx="26" cy="10" r="0.5" fill="var(--muted-foreground)" fillOpacity="0.06" />
+                  <circle cx="14" cy="28" r="0.5" fill="var(--muted-foreground)" fillOpacity="0.06" />
                 </pattern>
 
                 <linearGradient id="fillStoreVisits" x1="0" y1="0" x2="0" y2="1">

--- a/registry/default/blocks/charts/area-charts/area-chart-4.tsx
+++ b/registry/default/blocks/charts/area-charts/area-chart-4.tsx
@@ -118,7 +118,7 @@ export default function AreaChart4() {
     <div className="min-h-screen flex items-center justify-center p-6 lg:p-8">
       <Card className="w-full lg:max-w-4xl rounded-2xl">
         <CardHeader className="min-h-auto py-6 border-0">
-          <CardTitle className="text-xl font-semibold">Order sOverview</CardTitle>
+          <CardTitle className="text-xl font-semibold">Orders Overview</CardTitle>
           <CardToolbar>
             <ToggleGroup
               type="single"
@@ -227,7 +227,7 @@ export default function AreaChart4() {
                   dataKey="period"
                   axisLine={false}
                   tickLine={false}
-                  tick={{ fontSize: 12, fill: 'hsl(var(--muted-foreground))' }}
+                  tick={{ fontSize: 12, fill: 'var(--muted-foreground)' }}
                   tickMargin={8}
                   interval={0}
                   includeHidden={true}
@@ -237,7 +237,7 @@ export default function AreaChart4() {
                   hide={true}
                   axisLine={false}
                   tickLine={false}
-                  tick={{ fontSize: 11, fill: 'hsl(var(--muted-foreground))' }}
+                  tick={{ fontSize: 11, fill: 'var(--muted-foreground)' }}
                   tickFormatter={(value) => `$${value >= 1000 ? `${(value / 1000).toFixed(0)}K` : value}`}
                   tickMargin={8}
                   domain={[0, 'dataMax']}

--- a/registry/default/components/drawer/default.tsx
+++ b/registry/default/components/drawer/default.tsx
@@ -109,7 +109,7 @@ export default function Component() {
                     dataKey="goal"
                     style={
                       {
-                        fill: 'hsl(var(--foreground))',
+                        fill: 'var(--foreground)',
                         opacity: 0.9,
                       } as React.CSSProperties
                     }


### PR DESCRIPTION
## Changes
- **Drawer**: Removed `hsl()` wrapped from bar chart fill color
- **Area Chart 2**: Removed `hsl()` wrapped from bar chart fill color
- **Area Chart 4**: Removed `hsl()` wrapped from bar chart fill color + fixed typo
## Preview
### Drawer
Before
<img width="387" height="470" alt="drawer-before" src="https://github.com/user-attachments/assets/1abe84d2-795c-4e02-93ab-597e3349b195" />
After
<img width="387" height="470" alt="drawer-after" src="https://github.com/user-attachments/assets/626e2ea7-9b3a-4e82-9f0c-fe92c6ece1bc" />
### Area Chart 2
Before - light mode
<img width="975" height="605" alt="chart-2-ligh-before" src="https://github.com/user-attachments/assets/0e4fe285-26d8-4b44-81e5-3a18f73924a6" />
After - light mode
<img width="975" height="605" alt="chart-2-light-after" src="https://github.com/user-attachments/assets/113d2af5-ca5a-4909-95f8-075b9ac6b7e4" />
Before - dark mode
<img width="975" height="605" alt="chart-2-dark-before" src="https://github.com/user-attachments/assets/68e3fb26-5a98-42cf-a238-aa8d339038cc" />
After - dark mode
<img width="975" height="605" alt="chart-2-dark-after" src="https://github.com/user-attachments/assets/fb7f9b04-f448-4a58-9862-9abc492f7f5d" />
### Area Chart 4
Before
<img width="913" height="539" alt="chart-4-after" src="https://github.com/user-attachments/assets/b9a09bc2-7821-4174-8e76-5eff298ec52a" />
After
<img width="913" height="539" alt="chart-4-before" src="https://github.com/user-attachments/assets/6cdf09b7-5de0-4949-9808-9b8e8945b617" />
## Checklist
- [x] Ran `npx prettier --write <path to files>`
- [x] Ran `npx eslint <path to files>`