### PR TITLE
Do not call TooltipProvider for every Tooltip

### DIFF
--- a/registry/default/ui/base-tooltip.tsx
+++ b/registry/default/ui/base-tooltip.tsx
@@ -9,9 +9,7 @@ function TooltipProvider({ delay = 0, ...props }: React.ComponentProps<typeof To
 
 function Tooltip({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
   return (
-    <TooltipProvider>
-      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
-    </TooltipProvider>
+    <TooltipPrimitive.Root data-slot="tooltip" {...props} />
   );
 }
 


### PR DESCRIPTION
Do not call TooltipProvider for every Tooltip, because you won’t be able to set the delay for a tooltip or tooltip group.