### PR TITLE
fix(components): update site header responsivity

### DIFF
--- a/components/command-menu.tsx
+++ b/components/command-menu.tsx
@@ -76,7 +76,7 @@ export function CommandMenu({ ...props }: DialogProps) {
         variant="outline"
         mode="input"
         size="sm"
-        className={cn('h-8 relative py-0 pl-2 sm:pr-12 sm:w-40 lg:w-48')}
+        className={cn('h-8 relative py-0 pl-2 sm:pr-12 sm:w-40 xl:w-48')}
         onClick={() => {
           setOpen(true);
           trackEvent({

--- a/components/main-nav.tsx
+++ b/components/main-nav.tsx
@@ -25,7 +25,7 @@ export function MainNav() {
   };
 
   return (
-    <div className="itesm-center justify-center mr-4 hidden md:flex">
+    <div className="itesm-center justify-center mr-4 hidden lg:flex">
       <nav className="flex items-center gap-4 text-sm font-medium xl:gap-6">
         {sitemapConfig.mainNav.map((item: MainNavItem) => (
           <Link

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -26,7 +26,7 @@ export function MobileNav() {
   );
 
   return (
-    <div className="flex md:hidden items-center gap-1.5">
+    <div className="flex lg:hidden items-center gap-1.5">
       <Drawer open={open} onOpenChange={onOpenChange}>
         <DrawerTrigger asChild>
           <Button variant="ghost" className="size-8 p-0 -ms-2.5">

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -64,21 +64,21 @@ export function SiteHeader() {
       >
         <MobileNav />
 
-        <div className="hidden md:flex items-center gap-3.5">
+        <div className="hidden lg:flex items-center gap-3.5">
           <Link href="/" className="mr-10 flex items-center gap-2">
             <Image
               src="/brand/logo-text-light.svg"
               alt={siteConfig.name}
               width={75}
               height={0}
-              className="dark:hidden"
+              className="dark:hidden shrink-0"
             />
             <Image
               src="/brand/logo-text-dark.svg"
               alt={siteConfig.name}
               width={75}
               height={0}
-              className="hidden dark:inline-block"
+              className="hidden dark:inline-block shrink-0"
             />
           </Link>
           <MainNav />


### PR DESCRIPTION
## Changes

- **command-menu:** change to `w-48` at `xl` breakpoint instead of `lg`
- **main-nav:** change from `hidden` to `flex` at `lg` breakpoint instead of `md`
- **mobile-nav:** change from `flex` to `hidden` at `lg` breakpoint instead of `md`
- **site-header:** add `shrink-0` to logo images, change from `hidden` to `flex` at `lg` breakpoint instead of `md`

## Preview

Before:
https://github.com/user-attachments/assets/99433a36-14da-4371-8b56-d85bcaacd8a2

<img width="768" height="70" alt="768-before" src="https://github.com/user-attachments/assets/c126e4c3-8e78-445d-94e4-5115a2367bdd" />

<img width="1024" height="70" alt="1024-before" src="https://github.com/user-attachments/assets/473d8749-3a44-4fdc-848d-132118730835" />


After:
https://github.com/user-attachments/assets/4f8ff94d-d1fd-435e-b521-676a62565ee9

<img width="768" height="70" alt="768-after" src="https://github.com/user-attachments/assets/ceab04ef-48ca-4d5f-b8bf-97c0f0e65d42" />

<img width="1024" height="70" alt="1024-after" src="https://github.com/user-attachments/assets/c69b56f8-41d8-42c3-9758-0e8350374056" />

## Checklist

- [x] ran `npx prettier --write <path to files>`
- [x] ran `npx eslint <path to files> `