### PR TITLE
docs(button): update size example label from Xsmall to Large

### DIFF
--- a/registry/default/components/button/size.tsx
+++ b/registry/default/components/button/size.tsx
@@ -18,7 +18,7 @@ export default function ButtonDemo() {
         </Button>
         <Button variant="outline" size="lg">
           <UserPen />
-          Xsmall
+          Large
         </Button>
       </div>
       <div className="flex items-center gap-4">


### PR DESCRIPTION
The Button size example shows `size="lg"` but the label reads `Xsmall`. This PR updates the label to `Large` to match the actual `size` prop value.