### PR TITLE
fix: give an unique element id and update htmlFor attribute

### DIFF
--- a/registry/default/components/switch/size.tsx
+++ b/registry/default/components/switch/size.tsx
@@ -37,8 +37,8 @@ export default function SwitchDemo() {
           <Label htmlFor="compact-size-lg">Large</Label>
         </div>
         <div className="flex items-center space-x-2">
-          <Switch id="compact-size-lg" size="xl" shape="square" />
-          <Label htmlFor="compact-size-lg">XLarge</Label>
+          <Switch id="compact-size-xl" size="xl" shape="square" />
+          <Label htmlFor="compact-size-xl">XLarge</Label>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This pull request makes a small update to the `SwitchDemo` component to fix the labeling and `id` for the "XLarge" switch size.

* Corrected the `id` and `htmlFor` attributes for the "XLarge" switch from `compact-size-lg` to `compact-size-xl` to match the intended size and improve accessibility.