### PR TITLE
fix: update package installation commands to use @base-ui/react

### DIFF
--- a/content/docs/(components)/base-tabs.mdx
+++ b/content/docs/(components)/base-tabs.mdx
@@ -29,7 +29,7 @@ Refer to the [Installation Guide](/docs/installation) for detailed instructions 
 ### Install dependencies
 
 ```bash
-npm i @base-ui-components/react
+npm i @base-ui/react
 ```
 
 <Step>

--- a/content/docs/(components)/base-toggle-group.mdx
+++ b/content/docs/(components)/base-toggle-group.mdx
@@ -26,7 +26,7 @@ component: true
 Install the following dependencies:
 
 ```bash
-npm i @base-ui-components/react/toggle-group
+npm i @base-ui/react/toggle-group
 ```
 
 </Step>

--- a/content/docs/(components)/base-toggle.mdx
+++ b/content/docs/(components)/base-toggle.mdx
@@ -26,7 +26,7 @@ component: true
 Install the following dependencies:
 
 ```bash
-npm i @base-ui-components/react/toggle
+npm i @base-ui/react/toggle
 ```
 
 </Step>

--- a/content/docs/(getting-started)/installation.mdx
+++ b/content/docs/(getting-started)/installation.mdx
@@ -43,7 +43,7 @@ npm i radix-ui
 Follow [Base UI Installation Guide](https://base-ui.com/react/overview/quick-start) to install Base UI package.
 
 ```bash
-npm i @base-ui-components/react
+npm i @base-ui/react
 ```
 
 ### Install Motion

--- a/public/docs/base-tabs.md
+++ b/public/docs/base-tabs.md
@@ -18,7 +18,7 @@ Refer to the [Installation Guide](/docs/installation) for detailed instructions 
 ### 3. Install dependencies
 
 ```bash
-npm i @base-ui-components/react
+npm i @base-ui/react
 ```
 
 Copy and paste the following code into your project's `components/ui/base-tabs.tsx` file.

--- a/public/docs/base-toggle-group.md
+++ b/public/docs/base-toggle-group.md
@@ -14,7 +14,7 @@ Manual
 Install the following dependencies:
 
 ```bash
-npm i @base-ui-components/react/toggle-group
+npm i @base-ui/react/toggle-group
 ```
 
 Copy and paste the following code into your project's `components/ui/base-toggle-group.tsx` file.

--- a/public/docs/base-toggle.md
+++ b/public/docs/base-toggle.md
@@ -14,7 +14,7 @@ Manual
 Install the following dependencies:
 
 ```bash
-npm i @base-ui-components/react/toggle
+npm i @base-ui/react/toggle
 ```
 
 Copy and paste the following code into your project's `components/ui/base-toggle.tsx` file.

--- a/public/docs/installation.md
+++ b/public/docs/installation.md
@@ -38,7 +38,7 @@ npm i radix-ui
 Follow [Base UI Installation Guide](https://base-ui.com/react/overview/quick-start) to install Base UI package.
 
 ```bash
-npm i @base-ui-components/react
+npm i @base-ui/react
 ```
 
 ### 5. Install Motion

--- a/static/docs/(components)/base-tabs.md
+++ b/static/docs/(components)/base-tabs.md
@@ -12,7 +12,7 @@ Refer to the [Installation Guide](/docs/installation) for detailed instructions 
 ### 3. Install dependencies
 
 ```bash
-npm i @base-ui-components/react
+npm i @base-ui/react
 ```
 
 Copy and paste the following code into your project's `components/ui/base-tabs.tsx` file.

--- a/static/docs/(components)/base-toggle-group.md
+++ b/static/docs/(components)/base-toggle-group.md
@@ -8,7 +8,7 @@ Manual
 Install the following dependencies:
 
 ```bash
-npm i @base-ui-components/react/toggle-group
+npm i @@base-ui/react/toggle-group
 ```
 
 Copy and paste the following code into your project's `components/ui/base-toggle-group.tsx` file.

--- a/static/docs/(components)/base-toggle.md
+++ b/static/docs/(components)/base-toggle.md
@@ -8,7 +8,7 @@ Manual
 Install the following dependencies:
 
 ```bash
-npm i @base-ui-components/react/toggle
+npm i @base-ui/react/toggle
 ```
 
 Copy and paste the following code into your project's `components/ui/base-toggle.tsx` file.

--- a/static/docs/(getting-started)/installation.md
+++ b/static/docs/(getting-started)/installation.md
@@ -33,7 +33,7 @@ npm i radix-ui
 Follow [Base UI Installation Guide](https://base-ui.com/react/overview/quick-start) to install Base UI package.
 
 ```bash
-npm i @base-ui-components/react
+npm i @base-ui/react
 ```
 
 ### 5. Install Motion


### PR DESCRIPTION
Thanks for this great UI library — it’s beautiful and elegant.

I noticed a small issue in the Base UI docs: the installation instructions have changed upstream, but this repo still had the old steps. This PR updates the installation description to match the latest Base UI instructions.

No code changes — documentation only.

[reference:  base ui](https://base-ui.com/react/overview/quick-start#install-the-library )