### PR TITLE
fix: improve drag handling on mobile display

### DIFF
--- a/registry-reui/bases/radix/reui/sortable.tsx
+++ b/registry-reui/bases/radix/reui/sortable.tsx
@@ -27,7 +27,8 @@ import {
   KeyboardSensor,
   MeasuringStrategy,
   Modifiers,
-  PointerSensor,
+  MouseSensor,
+  TouchSensor,
   UniqueIdentifier,
   useSensor,
   useSensors,
@@ -124,9 +125,15 @@ function Sortable<T>({
   useLayoutEffect(() => setMounted(true), [])
 
   const sensors = useSensors(
-    useSensor(PointerSensor, {
+    useSensor(MouseSensor, {
       activationConstraint: {
         distance: 10,
+      },
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: {
+        delay: 250,
+        tolerance: 5,
       },
     }),
     useSensor(KeyboardSensor, {
@@ -268,6 +275,19 @@ function SortableItem({
 }: SortableItemProps) {
   const isOverlay = useContext(IsOverlayContext)
 
+  const {
+    setNodeRef,
+    transform,
+    transition,
+    attributes,
+    listeners,
+    isDragging: isSortableDragging,
+  } = useSortable({
+    id: value,
+    disabled: disabled || isOverlay,
+    animateLayoutChanges,
+  })
+
   if (isOverlay) {
     const Comp = asChild ? Slot.Root : "div"
 
@@ -287,19 +307,6 @@ function SortableItem({
       </SortableItemContext.Provider>
     )
   }
-
-  const {
-    setNodeRef,
-    transform,
-    transition,
-    attributes,
-    listeners,
-    isDragging: isSortableDragging,
-  } = useSortable({
-    id: value,
-    disabled,
-    animateLayoutChanges,
-  })
 
   const style = {
     transition,


### PR DESCRIPTION
This pull request makes a small update to the `Sortable` component to fix the drag-and-drop functionality on mobile devices. The changes are as follows:
- Replace PointerSensor with MouseSensor + TouchSensor (delay: 250ms, tolerance: 5px) to enable drag-and-drop on mobile devices
- Move useSortable hook call before the isOverlay early return in SortableItem to comply with React's rules of hooks (no conditional hook calls)
- Pass `disabled: disabled || isOverlay` to useSortable so overlay clones do not register as sortable targets