### PR TITLE
docs(mcp): removed wrong dlx in the init command

### DIFF
--- a/content/docs/(root)/mcp.mdx
+++ b/content/docs/(root)/mcp.mdx
@@ -10,7 +10,7 @@ MCP is an open protocol that standardizes how applications provide context to LL
 Run the following command to configure the mcp server:
 
 ```bash
-npx dlx shadcn@latest mcp init
+npx shadcn@latest mcp init
 ```
 
 Select your MCP client as prompted, then enable the MCP server in your client to finish setup.


### PR DESCRIPTION
The MCP docs currently have a dlx  in the init command no mater  the selected package manager <img width="752" height="101" src="https://github.com/user-attachments/assets/f81ef65c-43e4-4adb-8afb-8f2fc930960a">\
This pr removes the wrong dlx/duplicated dlx from the mcp init command
