### PR TITLE
docs: fix shadcn CLI command in MCP and Registry docs

### DIFF
--- a/content/docs/(root)/mcp.mdx
+++ b/content/docs/(root)/mcp.mdx
@@ -10,7 +10,7 @@ MCP is an open protocol that standardizes how applications provide context to LL
 Run the following command to configure the mcp server:
 
 ```bash
-npx dlx shadcn@latest mcp init
+npx shadcn@latest mcp init
 ```
 
 Select your MCP client as prompted, then enable the MCP server in your client to finish setup.

--- a/content/docs/(root)/registry.mdx
+++ b/content/docs/(root)/registry.mdx
@@ -22,11 +22,11 @@ Add the ReUI registry namespace to your `components.json`. Learn more about regi
 Install blocks via the shadcn CLI using the `@reui/{name}` syntax.
 
 ```bash
-npx dlx shadcn@latest add @reui/c-accordion-1
+npx shadcn@latest add @reui/c-accordion-1
 ```
 
 Install components via the shadcn CLI using the `@reui/{name}` syntax.
 
 ```bash
-npx dlx shadcn@latest add @reui/filters
+npx shadcn@latest add @reui/filters
 ```


### PR DESCRIPTION
## Summary

The install commands on [/docs/mcp](https://reui.io/docs/mcp) and [/docs/registry](https://reui.io/docs/registry) render as:

\`\`\`
npx dlx shadcn@latest mcp init
yarn dlx shadcn@latest mcp init
pnpm dlx dlx shadcn@latest mcp init
bunx --bun dlx shadcn@latest mcp init
\`\`\`

Three of the four are invalid:

| Tab | Rendered | Correct | Note |
|---|---|---|---|
| npm | \`npx dlx shadcn@latest …\` | \`npx shadcn@latest …\` | \`npx\` is itself a runner; there is no \`dlx\` subcommand |
| yarn | \`yarn dlx shadcn@latest …\` | ✅ same | Yarn Berry's runner |
| pnpm | \`pnpm dlx dlx shadcn@latest …\` | \`pnpm dlx shadcn@latest …\` | Duplicate \`dlx\` |
| bun | \`bunx --bun dlx shadcn@latest …\` | \`bunx --bun shadcn@latest …\` | \`bunx\` is \`bun x\`; no \`dlx\` |

## Root cause

The source \`.mdx\` files contain \`npx dlx shadcn@latest …\`. The tab generator in \`lib/highlight-code.ts\` takes a code block starting with \`npx\` and string-replaces the prefix to produce the yarn/pnpm/bun variants:

\`\`\`ts
// lib/highlight-code.ts
if (raw.startsWith("npx")) {
  node.properties["__npm__"]  = raw
  node.properties["__yarn__"] = raw.replace("npx", "yarn")
  node.properties["__pnpm__"] = raw.replace("npx", "pnpm dlx")
  node.properties["__bun__"]  = raw.replace("npx", "bunx --bun")
}
\`\`\`

Because the source already contains a stray \`dlx\`, it survives the replacement and cascades into \`pnpm dlx dlx …\` and \`bunx --bun dlx …\`. Dropping the \`dlx\` from the source makes every tab render correctly without any changes to the transformer.

## Changes

- \`content/docs/(root)/mcp.mdx\`: \`npx dlx shadcn@latest mcp init\` → \`npx shadcn@latest mcp init\`
- \`content/docs/(root)/registry.mdx\`: same fix for both \`add @reui/c-accordion-1\` and \`add @reui/filters\` snippets

## Test plan

- [ ] Visit \`/docs/mcp\` locally and confirm all four package-manager tabs render valid commands
- [ ] Visit \`/docs/registry\` locally and confirm all four tabs render valid commands for both code blocks
- [ ] (optional) Run \`npx shadcn@latest mcp init\` in a fresh project to confirm it works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)