### PR TITLE
fix: align package version with v2.2.0 changelog

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reui",
-  "version": "2.0.0",
+  "version": "2.2.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- align the root `package.json` version with the documented v2.2.0 release
- keep the change limited to repository metadata; the package remains private

## Root cause

Commit `14185b9` added the v2.2.0 changelog entry, but changed the root version from 2.1.8 back to 2.0.0. This restores the version to 2.2.0.

The same commit subject references a v2.0.0 release. Git tags currently stop at v2.0.1 and GitHub Releases are not in use, so this PR leaves any tag or release-marker policy to the maintainers.

## Validation

- parsed `package.json` and confirmed `version === "2.2.0"`
- `git diff --check`
